### PR TITLE
Fix: Add missing tokenizer training step in sample data pipeline

### DIFF
--- a/scripts/data/run_sample.sh
+++ b/scripts/data/run_sample.sh
@@ -68,6 +68,18 @@ if [[ ! -f "data/filtered/code_en_sample.txt" ]]; then
     --output-path data/filtered/code_en_sample.txt --force-exit
 fi
 
+# Train tokenizer if it doesn't exist 
+if [[ ! -f "${TOKENIZER_MODEL}" ]]; then
+  echo "[Data] Training tokenizer (vocab_size=32000, model_type=unigram)"
+  uv run python scripts/data/train_tokenizer.py \
+    --manifest configs/data/refinedweb_mixture_sample.yaml \
+    --vocab-size 32000 \
+    --output-dir artifacts/tokenizer/refinedweb_mix \
+    --log-file data/mixtures/refinedweb_mix_tokenizer.json
+else
+  echo "[Data] Tokenizer already exists at ${TOKENIZER_MODEL}"
+fi
+
 echo "[Data] Sharding filtered samples"
 uv run python scripts/data/process_mixture.py \
   configs/data/refinedweb_mixture_filtered.yaml \


### PR DESCRIPTION
## Summary
The `run_sample.sh` script was missing a critical step to train the tokenizer before attempting to shard data, causing an `OSError: Not found: "artifacts/tokenizer/refinedweb_mix/spm_32000_unigram.model"` on fresh clones.

## Problem
According to [docs/data_pipeline.md](docs/data_pipeline.md#1-train-tokenizer-multi-corpus-manifest) and [docs/guide.md](docs/guide.md), the data pipeline has three steps:
1. Train tokenizer
2. Filter datasets  
3. Shard filtered data (requires tokenizer)

The script was executing steps 2 and 3, but skipping step 1, causing it to fail when the tokenizer didn't exist.

## Solution
Added a check to train the tokenizer if it doesn't exist, using the documented defaults:
- vocab_size: 32000
- model_type: unigram  
- manifest: `configs/data/refinedweb_mixture_sample.yaml`

The fix is idempotent - it skips training if the tokenizer model already exists.

## Testing
Verified on macOS (M1) with Python 3.12.12:
```bash
# Fresh clone scenario
rm -rf artifacts/tokenizer/refinedweb_mix/
bash scripts/data/run_sample.sh
# Successfully trains tokenizer, then proceeds with filtering and sharding
```

## Files Changed
- `scripts/data/run_sample.sh`: Added tokenizer training step (lines 71-81)